### PR TITLE
Fallback object validation to laravel validator

### DIFF
--- a/src/ValidatingMiddleware.php
+++ b/src/ValidatingMiddleware.php
@@ -100,7 +100,7 @@ class ValidatingMiddleware
             $name = $property->getName();
             $value = $property->getValue($command);
 
-            if (in_array($name, ['rules', 'validationMessages'], true) || is_object($value)) {
+            if (in_array($name, ['rules', 'validationMessages'], true)) {
                 continue;
             }
 


### PR DESCRIPTION
This will allow to use the `file`, `image` and other rules when validating and fallback the object filter to the Laravel validator.

/cc @AltThree/owners 